### PR TITLE
feat: add layout wrapper and map styles

### DIFF
--- a/src/components/Map.css
+++ b/src/components/Map.css
@@ -1,0 +1,4 @@
+.map-container {
+  width: 100%;
+  height: 500px;
+}

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1,15 +1,12 @@
-import { MapContainer, TileLayer, Marker, Polyline } from "react-leaflet";
+import { MapContainer, TileLayer, Marker } from "react-leaflet";
 import "leaflet/dist/leaflet.css";
+import "./Map.css";
 
 const Map = () => {
   const position: [number, number] = [34.7818, 32.0853]; // Tel Aviv coords
 
   return (
-    <MapContainer
-      center={position}
-      zoom={10}
-      style={{ height: "500px", width: "100%" }}
-    >
+    <MapContainer center={position} zoom={10} className="map-container">
       <TileLayer url={`https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png`} />
       <Marker position={position} />
     </MapContainer>

--- a/src/pages/Home.css
+++ b/src/pages/Home.css
@@ -1,0 +1,23 @@
+.home-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  width: 100%;
+}
+
+.home-title {
+  margin: 0;
+}
+
+.home-truck-selector,
+.home-selected-truck,
+.home-map {
+  width: 100%;
+  text-align: center;
+}
+
+.home-map {
+  display: flex;
+  justify-content: center;
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,16 +1,23 @@
 import Map from "../components/Map";
 import TruckSelector from "../components/TruckSelector";
 import { useState } from "react";
+import "./Home.css";
 
 const Home = () => {
   const [selectedTruck, setSelectedTruck] = useState<string | null>(null);
 
   return (
-    <div>
-      <h1>AI Truck Helper</h1>
-      <TruckSelector onSelect={setSelectedTruck} />
-      {selectedTruck && <p>Selected Truck: {selectedTruck}</p>}
-      <Map />
+    <div className="home-wrapper">
+      <h1 className="home-title">AI Truck Helper</h1>
+      <div className="home-truck-selector">
+        <TruckSelector onSelect={setSelectedTruck} />
+      </div>
+      {selectedTruck && (
+        <p className="home-selected-truck">Selected Truck: {selectedTruck}</p>
+      )}
+      <div className="home-map">
+        <Map />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- structure Home page with flexbox wrapper and dedicated spacing classes
- move Leaflet map sizing to CSS and ensure it fits layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688dbac2679883239e5326bb4ed8cd5c